### PR TITLE
[PKG-4248] Update to 1.23.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,2 @@
-aggregate_check: false
 upload_channels:
   - sfe1ed40
-  - services
-channels:
-  - sfe1ed40
-  - services

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ about:
   license_family: Apache
   license_file: LICENSE
   doc_url: https://opentelemetry-python.readthedocs.io/en/latest/
-  doc_source_url: https://github.com/open-telemetry/opentelemetry-python/tree/main/docs
+  dev_url: https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelemetry-api
   description: |-
     OpenTelemetry, also known as OTel for short, is a vendor-neutral open-source
     Observability framework for instrumenting, generating, collecting, and exporting

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,7 @@ requirements:
   run:
     - deprecated >=1.2.6
     - aiocontextvars  # [py<37]
+    - importlib-metadata >=6.0,<7.0
     - python
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "opentelemetry-api" %}
-{% set version = "1.12.0" %}
-{% set sha256 = "740c2cf9aa75e76c208b3ee04b3b3b3721f58bbac8e97019174f07ec12cde7af" %}
+{% set version = "1.23.0" %}
+{% set sha256 = "14a766548c8dd2eb4dfc349739eb4c3893712a0daa996e5dbf945f9da665da9d" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,8 @@ source:
 
 build:
   number: 0
-  # noarch: python
-  skip: true  # [py<36]
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  skip: true  # [py<38]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/opentelemetry_api-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,8 +19,7 @@ requirements:
   host:
     - pip
     - python
-    - setuptools
-    - wheel
+    - hatchling
   run:
     - deprecated >=1.2.6
     - aiocontextvars  # [py<37]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ about:
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
-  doc_url: https://opentelemetry-python.readthedocs.io/en/latest/
+  doc_url: https://opentelemetry-python.readthedocs.io
   dev_url: https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelemetry-api
   description: |-
     OpenTelemetry, also known as OTel for short, is a vendor-neutral open-source


### PR DESCRIPTION
opentelemetry-api 1.23.0 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-4248](https://anaconda.atlassian.net/browse/PKG-4248) 
- [Upstream repository](https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelemetry-api)
- Upstream [changelog](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.23.0) / [diff](https://github.com/open-telemetry/opentelemetry-python/compare/v1.15.0...v1.23.0)

### Explanation of changes:

- Unable to run upstream tests as they require the `opentelemetry.test` module from the top level package and several missing dependencies.

[PKG-4248]: https://anaconda.atlassian.net/browse/PKG-4248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ