### PR TITLE
1.26 Update

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-upload_channels:
-  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "opentelemetry-api" %}
-{% set version = "1.23.0" %}
-{% set sha256 = "14a766548c8dd2eb4dfc349739eb4c3893712a0daa996e5dbf945f9da665da9d" %}
+{% set version = "1.26.0" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +7,9 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/opentelemetry_api-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: 2bd639e4bed5b18486fef0b5a520aaffde5a18fc225e808a1ac4df363f43a1ce
+  patches:
+    - patches/0000-fix-classifier-clash-in-pyproject.patch
 
 build:
   number: 0
@@ -22,8 +23,7 @@ requirements:
     - hatchling
   run:
     - deprecated >=1.2.6
-    - aiocontextvars  # [py<37]
-    - importlib-metadata >=6.0,<7.0
+    - importlib-metadata >=6.0,<=8.2.0
     - python
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,8 +8,6 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/opentelemetry_api-{{ version }}.tar.gz
   sha256: 2bd639e4bed5b18486fef0b5a520aaffde5a18fc225e808a1ac4df363f43a1ce
-  patches:
-    - patches/0000-fix-classifier-clash-in-pyproject.patch
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,6 +54,8 @@ about:
     it is natively supported by a number of vendors.
 
 extra:
+  skip-lints:
+    - invalid_url
   recipe-maintainers:
     - mariusvniekerk
     - marcelotrevisani

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,12 +17,13 @@ build:
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
+  build:
+    - patch # [not win]
+    - m2-patch  # [win]
   host:
     - pip
     - python
     - hatchling
-    - patch # [not win]
-    - m2-patch  # [win]
   run:
     - deprecated >=1.2.6
     - importlib-metadata >=6.0,<=8.2.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - pip
     - python
     - hatchling
+    - patch
   run:
     - deprecated >=1.2.6
     - importlib-metadata >=6.0,<=8.2.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - hatchling
   run:
     - deprecated >=1.2.6
-    - importlib-metadata >=6.0,<=8.2.0
+    - importlib-metadata >=6.0,<=8.0.0
     - python
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,9 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/opentelemetry_api-{{ version }}.tar.gz
   sha256: 2bd639e4bed5b18486fef0b5a520aaffde5a18fc225e808a1ac4df363f43a1ce
+  patches:
+    # added to avoid pip._internal.exceptions.MetadataGenerationFailed: metadata generation failed
+    - patches/0000-fix-classifier-clash-in-pyproject.patch
 
 build:
   number: 0
@@ -24,7 +27,7 @@ requirements:
     - hatchling
   run:
     - deprecated >=1.2.6
-    - importlib-metadata >=6.0,<=8.0.0
+    - importlib-metadata >=6.0,<=8.2.0
     - python
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,8 @@ requirements:
     - pip
     - python
     - hatchling
-    - patch
+    - patch # [not win]
+    - m2-patch  # [win]
   run:
     - deprecated >=1.2.6
     - importlib-metadata >=6.0,<=8.2.0

--- a/recipe/patches/0000-fix-classifier-clash-in-pyproject.patch
+++ b/recipe/patches/0000-fix-classifier-clash-in-pyproject.patch
@@ -1,0 +1,9 @@
+--- pyproject.toml
++++ pyproject.toml
+@@ -12,7 +12,6 @@
+ classifiers = [
+     "Development Status :: 5 - Production/Stable",
+-    "Framework :: OpenTelemetry",
+     "Intended Audience :: Developers",
+     "License :: OSI Approved :: Apache Software License",
+     "Programming Language :: Python",


### PR DESCRIPTION
opentelemetry-api 1.26

**Destination channel:** defaults

### Links

- [PKG-2422](https://anaconda.atlassian.net/browse/PKG-2422) 
- [Upstream repository](https://github.com/open-telemetry/opentelemetry-python/tree/master/opentelemetry-api)
- [Upstream changelog/diff](https://github.com/open-telemetry/opentelemetry-python/compare/v1.26.0...v1.25.0)
- Relevant dependency PRs:
  - ...

### Explanation of changes:
- **Updated OpenTelemetry-API to version 1.26**
  - Removed exclusive upload to Snowflake.
  - Added a patch for an issue in `pyproject.toml`.
  - Incremented `importlib-metadata`.


[PKG-2422]: https://anaconda.atlassian.net/browse/PKG-2422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ