### PR TITLE
V1.30.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "opentelemetry-api" %}
-{% set version = "1.26.0" %}
+{% set version = "1.30.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/opentelemetry_api-{{ version }}.tar.gz
-  sha256: 2bd639e4bed5b18486fef0b5a520aaffde5a18fc225e808a1ac4df363f43a1ce
   patches:
     # added to avoid pip._internal.exceptions.MetadataGenerationFailed: metadata generation failed
     - patches/0000-fix-classifier-clash-in-pyproject.patch
+  sha256: 375893400c1435bf623f7dfb3bcd44825fe6b56c34d0667c542ea8257b1a1240
 
 build:
   number: 0
@@ -27,7 +27,7 @@ requirements:
     - hatchling
   run:
     - deprecated >=1.2.6
-    - importlib-metadata >=6.0,<=8.2.0
+    - importlib-metadata >=6.0,<=8.5.0
     - python
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,9 +7,6 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/opentelemetry_api-{{ version }}.tar.gz
-  patches:
-    # added to avoid pip._internal.exceptions.MetadataGenerationFailed: metadata generation failed
-    - patches/0000-fix-classifier-clash-in-pyproject.patch
   sha256: 375893400c1435bf623f7dfb3bcd44825fe6b56c34d0667c542ea8257b1a1240
 
 build:
@@ -18,9 +15,6 @@ build:
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
-  build:
-    - patch # [not win]
-    - m2-patch  # [win]
   host:
     - pip
     - python

--- a/recipe/patches/0000-fix-classifier-clash-in-pyproject.patch
+++ b/recipe/patches/0000-fix-classifier-clash-in-pyproject.patch
@@ -1,9 +1,0 @@
---- pyproject.toml
-+++ pyproject.toml
-@@ -12,7 +12,6 @@
- classifiers = [
-     "Development Status :: 5 - Production/Stable",
--    "Framework :: OpenTelemetry",
-     "Intended Audience :: Developers",
-     "License :: OSI Approved :: Apache Software License",
-     "Programming Language :: Python",


### PR DESCRIPTION
opentelemetry-api  1.30.0

**Destination channel:**  defaults

### Links

- [PKG-7674](https://anaconda.atlassian.net/browse/PKG-7674) 
- [Upstream repository](https://github.com/open-telemetry/opentelemetry-python/tree/v1.30.0/opentelemetry-api)

### Explanation of changes:

- Bump version and SHA
- Build for 3.13
- Update pinnings


[PKG-7674]: https://anaconda.atlassian.net/browse/PKG-7674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ