### PR TITLE
opentelemetry-api 1.37.0 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
   run:
     - python
     - typing-extensions >=4.5.0
-    - importlib-metadata >=6.0,<8.8.0 # [py<312]
+    - importlib-metadata >=6.0,<8.8.0
 
 # Unable to run the tests, opentelemetry-test-utils is not in the main channel.
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
   run:
     - python
     - typing-extensions >=4.5.0
-    - importlib-metadata >=6.0,<=8.5.0
+    - importlib-metadata >=6.0,<8.8.0 # [py<312]
 
 # Unable to run the tests, opentelemetry-test-utils is not in the main channel.
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,18 +1,18 @@
 {% set name = "opentelemetry-api" %}
-{% set version = "1.30.0" %}
+{% set version = "1.37.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/opentelemetry_api-{{ version }}.tar.gz
-  sha256: 375893400c1435bf623f7dfb3bcd44825fe6b56c34d0667c542ea8257b1a1240
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
+  sha256: 540735b120355bd5112738ea53621f8d5edb35ebcd6fe21ada3ab1c61d1cd9a7
 
 build:
   number: 0
-  skip: true  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  skip: true  # [py<39]
 
 requirements:
   host:
@@ -20,10 +20,11 @@ requirements:
     - python
     - hatchling
   run:
-    - deprecated >=1.2.6
-    - importlib-metadata >=6.0,<=8.5.0
     - python
+    - typing-extensions >=4.5.0
+    - importlib-metadata >=6.0,<=8.5.0
 
+# Unable to run the tests, opentelemetry-test-utils is not in the main channel.
 test:
   imports:
     - opentelemetry


### PR DESCRIPTION
opentelemetry-api 1.37.0 

**Destination channel:** Defaults

### Links

- [PKG-9806]
- dev_url:        https://github.com/open-telemetry/opentelemetry-python/tree/v1.37.0
- conda_forge:    https://github.com/conda-forge/opentelemetry-api-feedstock
- pypi:           https://pypi.org/project/opentelemetry-api/1.37.0
- pypi inspector: https://inspector.pypi.io/project/opentelemetry-api/1.37.0

### Explanation of changes:

- new version number


[PKG-9806]: https://anaconda.atlassian.net/browse/PKG-9806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ