### PR TITLE
opentelemetry-api 1.38.0 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "opentelemetry-api" %}
-{% set version = "1.37.0" %}
+{% set version = "1.38.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
-  sha256: 540735b120355bd5112738ea53621f8d5edb35ebcd6fe21ada3ab1c61d1cd9a7
+  sha256: f4c193b5e8acb0912b06ac5b16321908dd0843d75049c091487322284a3eea12
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   skip: true  # [py<39]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
@@ -35,18 +35,18 @@ test:
     - pip
 
 about:
-  summary: OpenTelemetry Python / API
   home: https://github.com/open-telemetry/opentelemetry-python/tree/master/opentelemetry-api
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
-  doc_url: https://opentelemetry-python.readthedocs.io
-  dev_url: https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelemetry-api
+  summary: OpenTelemetry Python / API
   description: |-
     OpenTelemetry, also known as OTel for short, is a vendor-neutral open-source
     Observability framework for instrumenting, generating, collecting, and exporting
     telemetry data such as traces, metrics, logs. As an industry-standard
     it is natively supported by a number of vendors.
+  doc_url: https://opentelemetry-python.readthedocs.io
+  dev_url: https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelemetry-api
 
 extra:
   skip-lints:


### PR DESCRIPTION
opentelemetry-api 1.38.0 

**Destination channel:** Defaults

### Links

- [PKG-10840]
- dev_url:        https://github.com/open-telemetry/opentelemetry-python/tree/v1.38.0
- conda_forge:    https://github.com/conda-forge/opentelemetry-api-feedstock
- pypi:           https://pypi.org/project/opentelemetry-api/1.38.0
- pypi inspector: https://inspector.pypi.io/project/opentelemetry-api/1.38.0

### Explanation of changes:

- new version number


[PKG-10840]: https://anaconda.atlassian.net/browse/PKG-10840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ