### PR TITLE
fix 1.15 with setuptools<82

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,2 @@
-aggregate_check: false
-upload_channels:
-  - sfe1ed40
-  - services
 channels:
   - sfe1ed40
-  - services

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,36 +1,32 @@
 {% set name = "opentelemetry-api" %}
-{% set version = "1.12.0" %}
-{% set sha256 = "740c2cf9aa75e76c208b3ee04b3b3b3721f58bbac8e97019174f07ec12cde7af" %}
+{% set version = "1.15.0" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
+  sha256: 79ab791b4aaad27acc3dc3ba01596db5b5aac2ef75c70622c6038051d6c2cded
 
 build:
-  number: 2
-  # noarch: python
-  skip: true  # [py<36]
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  number: 3
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  skip: true  # [py<37]
 
 requirements:
   host:
     - pip
     - python
-    - setuptools
-    - wheel
+    - hatchling
   run:
-    - deprecated >=1.2.6
-    - aiocontextvars  # [py<37]
     - python
+    - deprecated >=1.2.6
+    - setuptools >=16.0,<82
 
 test:
   imports:
     - opentelemetry
-    - opentelemetry.context
   commands:
     - pip check
   requires:


### PR DESCRIPTION
Add setuptools upper-bound
upstream: https://inspector.pypi.io/project/opentelemetry-api/1.15.0/packages/1b/56/e5de0c3fddb260b72853b5391d205081ffb7a117d374e52cd01a0fff9906/opentelemetry_api-1.15.0.tar.gz/opentelemetry_api-1.15.0/pyproject.toml#line.27