### PR TITLE
opentelemetry-api 1.40.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,1 @@
 staging_channel_upload_target: otel-1.40.0-staging
-
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,0 @@
-staging_channel_upload_target: otel-1.40.0-staging

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,4 @@
+staging_channel_upload_target: otel-1.40.0-staging
+
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "opentelemetry-api" %}
-{% set version = "1.38.0" %}
+{% set version = "1.40.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
-  sha256: f4c193b5e8acb0912b06ac5b16321908dd0843d75049c091487322284a3eea12
+  sha256: 159be641c0b04d11e9ecd576906462773eb97ae1b657730f0ecf64d32071569f
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ test:
     - pip
 
 about:
-  home: https://github.com/open-telemetry/opentelemetry-python/tree/master/opentelemetry-api
+  home: https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelemetry-api
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
@@ -49,8 +49,6 @@ about:
   dev_url: https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelemetry-api
 
 extra:
-  skip-lints:
-    - invalid_url
   recipe-maintainers:
     - mariusvniekerk
     - marcelotrevisani


### PR DESCRIPTION
opentelemetry-api 1.40.0

**Destination channel:** defaults (via otel-1.40.0-staging during chain build)

### Links

- [PKG-14560](https://anaconda.atlassian.net/browse/PKG-14560)
- Parent epic: [PKG-13074](https://anaconda.atlassian.net/browse/PKG-13074)
- Blocks: [PKG-14486](https://anaconda.atlassian.net/browse/PKG-14486) (pydantic-ai)
- [PyPI release](https://pypi.org/project/opentelemetry-api/1.40.0/)

### Explanation of changes:

- Bump opentelemetry-api 1.38.0 -> 1.40.0.
- Required to unblock logfire 4.32.1 (needs OTel >=1.39.0,<1.41.0). Tier 1 (leaf) of the 8-package OTel ecosystem lockstep update; this PR has no inter-OTel deps.


[PKG-14560]: https://anaconda.atlassian.net/browse/PKG-14560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-13074]: https://anaconda.atlassian.net/browse/PKG-13074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-14486]: https://anaconda.atlassian.net/browse/PKG-14486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ